### PR TITLE
Use newer Webrick

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_BUILD__POSIX___SPAWN: "--with-cflags=-Wno-incompatible-function-pointer-types"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
 
 PLATFORMS
   ruby
@@ -95,4 +95,4 @@ DEPENDENCIES
   rake (~> 13.2)
 
 BUNDLED WITH
-   2.1.4
+   2.5.18


### PR DESCRIPTION
In addition, ensure that posix-spawn can build on e.g. macOS m2. Fixes CVE-2024-47220
